### PR TITLE
combining-types/type-aliases

### DIFF
--- a/combining-types/type-aliases.ts
+++ b/combining-types/type-aliases.ts
@@ -1,0 +1,26 @@
+interface Employee {
+  id: number
+  name: string
+  role: string
+}
+
+interface Payroll {
+  employee: Employee
+  salary: number
+}
+
+type EmployeeWithSalary = Employee & Pick<Payroll, "salary">
+
+function printEmployeeWithSalary({ name, role, salary }: EmployeeWithSalary) {
+  console.log(`Name: ${name}, Role: ${role}, Salary: $${salary}`)
+}
+
+const employee: Employee = { id: 1, name: "John", role: "Developer" }
+const payroll: Payroll = { employee, salary: 50000 }
+
+const employeeWithSalary: EmployeeWithSalary = {
+  ...employee,
+  salary: payroll.salary,
+}
+
+printEmployeeWithSalary(employeeWithSalary) // "Name: John, Role: Developer, Salary: $50000"


### PR DESCRIPTION
A Type Alias in TypeScript allows you to create a new name for a type.

Here’s an example:

```ts
type Name = string
type Age = number
type User = { name: Name; age: Age }

const user: User = { name: 'John', age: 30 }
```

## Exercise

- [x] Type Aliases: 6eadafe8338b2c9367c70ec075b55bb040ad2664