### PR TITLE
combining-types/keyof-operator

### DIFF
--- a/combining-types/keyof-operator.ts
+++ b/combining-types/keyof-operator.ts
@@ -1,0 +1,20 @@
+interface Task {
+  id: number
+  title: string
+  description: string
+  completed: boolean
+}
+
+function getProperty(task: Task, key: keyof Task) {
+  return task[key]
+}
+
+const task: Task = {
+  id: 1,
+  title: "Complete Assignment",
+  description: "Finish the TypeScript assignment.",
+  completed: false,
+}
+
+const title = getProperty(task, "title") // "Complete Assignment"
+const completed = getProperty(task, "completed") // false


### PR DESCRIPTION
The `keyof` operator in TypeScript is used to get the union of keys from an object type. Here’s an example of how it can be used:

```ts
interface User {
  name: string
  age: number
  location: string
}

type UserKeys = keyof User; // "name" | "age" | "location"

const key: UserKeys = 'name'
```

In this example, UserKeys is a type that represents the union of keys from the User interface, which is `"name" | "age" | "location"`. And a constant named key with the type UserKeys is declared with the value `"name"`.

![image](https://github.com/wesleydmscn-docs/typescript-roadmap/assets/124368605/e262b3d7-b2ab-4094-806b-6df1f3a6d4b4)

## Exercise

- [x] keyof Operator: 68d23e5b8bfbd104ddcb6b188c95fe699348675f