### PR TITLE
type-guards/instanceof-operator

### DIFF
--- a/type-guards/instanceof-operator.ts
+++ b/type-guards/instanceof-operator.ts
@@ -1,0 +1,35 @@
+class Animal {
+  name: string
+
+  constructor(name: string) {
+    this.name = name
+  }
+}
+
+class Dog extends Animal {
+  breed: string
+
+  constructor(name: string, breed: string) {
+    super(name)
+    this.breed = breed
+  }
+}
+
+class Cat extends Animal {
+  color: string
+
+  constructor(name: string, color: string) {
+    super(name)
+    this.color = color
+  }
+}
+
+function isDog(animal: object) {
+  return animal instanceof Dog
+}
+
+const dog = new Dog("Buddy", "Golden Retriever")
+const cat = new Cat("Whiskers", "Gray")
+
+const result1 = isDog(dog) // true
+const result2 = isDog(cat) // false


### PR DESCRIPTION
The `instanceof` operator is a way to narrow down the type of a variable. It is used to check if an object is an instance of a class.

```ts
class Bird {
  fly() {
    console.log('flying...')
  }
  layEggs() {
    console.log('laying eggs...')
  }
}

const pet = new Bird()

// instanceof
if (pet instanceof Bird) {
  pet.fly()
} else {
  console.log('pet is not a bird')
}
```

## Exercise

- [x] instanceof Operator: 7a8a6a99dc431713161011284f60668ac0e365de