### PR TITLE
type-guards/type-predicates

### DIFF
--- a/type-guards/type-predicates.ts
+++ b/type-guards/type-predicates.ts
@@ -1,0 +1,15 @@
+interface Employee {
+  id: number
+  name: string
+  role: string
+}
+
+function isManager(employee: Employee) {
+  return employee.role === "Manager"
+}
+
+const employee1: Employee = { id: 1, name: "John", role: "Manager" }
+const employee2: Employee = { id: 2, name: "Alice", role: "Developer" }
+
+const result1 = isManager(employee1) // true
+const result2 = isManager(employee2) // false


### PR DESCRIPTION
Type predicates are functions that return a boolean value. They are used to narrow the type of a variable. Type predicates are used in type guards.

![image](https://github.com/wesleydmscn-docs/typescript-roadmap/assets/124368605/2acfa699-21a1-4c06-8c80-2e8ab3776418)

## Exercise

- [x] Type Predicate: 3592c4821fb387ce17a5128b8393e92bc8b4adea