### PR TITLE
utility-types/partial

### DIFF
--- a/utility-types/partial.ts
+++ b/utility-types/partial.ts
@@ -1,0 +1,29 @@
+type User = {
+  id: number
+  name: string
+  email: string
+}
+
+function updateUser(user: User, updates: Partial<User>): User {
+  const userCopy = { ...user }
+
+  for (const key in updates) {
+    if (key in user) {
+      userCopy[key] = updates[key]
+    }
+  }
+
+  return userCopy
+}
+
+const user: User = {
+  id: 1,
+  name: "John",
+  email: "john@example.com",
+}
+
+const updates: Partial<User> = {
+  name: "John Doe",
+}
+
+console.log(updateUser(user, updates)) // { id: 1, name: "John Doe", email: "john@example.com" }


### PR DESCRIPTION
The Partial type in TypeScript allows you to make all properties of a type optional. This is useful when you need to create an object with only a subset of the properties of an existing type.

## Exercise

- [x] Partial: 58f30900f8b3c3c933385b4d219f111631e8a86f