### PR TITLE
utility-types/pick

### DIFF
--- a/utility-types/pick.ts
+++ b/utility-types/pick.ts
@@ -1,0 +1,25 @@
+function pickProperties<T extends {}, K extends keyof T>(
+  source: T,
+  keys: string[]
+): Pick<T, K> {
+  const pickedProperties = {} as Pick<T, K>
+
+  for (const key of keys) {
+    if (key in source) {
+      pickedProperties[key] = source[key]
+    }
+  }
+
+  return pickedProperties
+}
+
+const source = {
+  id: 1,
+  name: "John Doe",
+  age: 30,
+  email: "john@example.com",
+}
+
+const keys = ["name", "email"]
+
+console.log(pickProperties(source, keys))


### PR DESCRIPTION
Pick constructs a type by picking the set of properties Keys (string literal or union of string literals) from Type.

## Exercise

- [x] Pick: 80b2a7a9656c464611a64f149a15f6c624f6912f