### PR TITLE
utility-types/omit

### DIFF
--- a/utility-types/omit.ts
+++ b/utility-types/omit.ts
@@ -1,0 +1,27 @@
+type User = {
+  id: number
+  name: string
+  email: string
+  phone: string
+}
+
+function omitPhone(user: User) {
+  const newObj = {} as Omit<User, "phone">
+
+  for (const property in user) {
+    if (property !== "phone") {
+      newObj[property] = user[property]
+    }
+  }
+
+  return newObj
+}
+
+const result = omitPhone({
+  id: 1,
+  name: "Wesley",
+  email: "test@email.com",
+  phone: "0000000000",
+})
+
+console.log(result)


### PR DESCRIPTION
Omit constructs a type by picking all properties from Type and then removing Keys (string literal or union of string literals).

## Exercise

- [x] Omit: 43a66cd8d2fda81616eb608d4257efb47bc69063