### PR TITLE
utility-types/readonly

### DIFF
--- a/utility-types/readonly.ts
+++ b/utility-types/readonly.ts
@@ -1,0 +1,18 @@
+interface Person {
+  name: string
+  age: number
+  email: string
+}
+
+function freezeObject(object: Person) {
+  const freeze: Readonly<Person> = object
+  return freeze
+}
+
+const person: Person = {
+  name: "Alice",
+  age: 30,
+  email: "alice@example.com",
+}
+
+const frozenPerson = freezeObject(person)


### PR DESCRIPTION
Readonly constructs a type with all properties of Type set to readonly, meaning the properties of the constructed type cannot be reassigned.

## Exercise

- [x] Readonly: 338e65d18bb85a1a97f2016116e85ad258bbbc06