### PR TITLE
utility-types/record

### DIFF
--- a/utility-types/record.ts
+++ b/utility-types/record.ts
@@ -1,0 +1,13 @@
+interface TaskList {
+  title: string
+  tasks: Record<string, boolean>
+}
+
+const sampleTaskList: TaskList = {
+  title: "My Task List",
+  tasks: {
+    "Task 1": true,
+    "Task 2": false,
+    "Task 3": true,
+  },
+}


### PR DESCRIPTION
Record constructs an object type whose property keys are Keys and whose property values are Type. This utility can be used to map the properties of a type to another type.

## Exercise

- [x] Record: bb3cfe90ac4a0652ea42b3d2660cbf91c6a8d1fd