### PR TITLE
utility-types/exclude

### DIFF
--- a/utility-types/exclude.ts
+++ b/utility-types/exclude.ts
@@ -1,0 +1,6 @@
+type AvailablePermissions = "read" | "write" | "delete" | "edit" | "admin"
+type ExcludedPermissions = "admin" | "edit"
+
+type FilteredPermissions = Exclude<AvailablePermissions, ExcludedPermissions>
+
+const userPermissions: FilteredPermissions[] = ["read", "write", "delete"]


### PR DESCRIPTION
Exclude constructs a type by excluding from UnionType all union members that are assignable to ExcludedMembers.

## Exercise

- [x] Exclude: f4c9fd59bfcb87520b221d0754ee51d522f66efb