### PR TITLE
advanced-types/mapped-types

### DIFF
--- a/advanced-types/mapped-types.ts
+++ b/advanced-types/mapped-types.ts
@@ -1,0 +1,18 @@
+type OriginalObject = {
+  name: string
+  age: number
+  isAdmin: boolean
+}
+
+type ReadOnly<T> = {
+  readonly [Property in keyof T]: T[Property]
+}
+
+const readOnlyObject: ReadOnly<OriginalObject> = {
+  name: "Alice",
+  age: 30,
+  isAdmin: true,
+}
+
+// Now try assigning a new value to a property of the readOnlyObject object
+// readOnlyObject.name = "Bob" // This should generate a compilation error


### PR DESCRIPTION
Mapped types in TypeScript are a way to create a new type based on an existing type, where each property of the existing type is transformed in some way. Mapped types are declared using a combination of the `keyof `operator and a type that maps each property of the existing type to a new property type.

## Exercise

- [x] MappedTypes: b1cee63b520f8ee1483b43681269facf3619f452